### PR TITLE
optimize

### DIFF
--- a/pages/leftSlide/leftSlide.js
+++ b/pages/leftSlide/leftSlide.js
@@ -8,25 +8,30 @@ Page({
     itemData,
   },
   touchS: function (e) {  // touchstart
-    let startX = App.Touches.getClientX(e)
-    startX && this.setData({ startX })
+    this.setData({ itemData: App.Touches.touchStart(e) })
   },
   touchM: function (e) {  // touchmove
-    let itemData = App.Touches.touchM(e, this.data.itemData, this.data.startX)
-    itemData && this.setData({ itemData })
-
+    let item = App.Touches.touchMove(e)
+    item && this.setData({ [`itemData[${App.Touches.getItemIndex(e)}]`]: item })
   },
   touchE: function (e) {  // touchend
-    const width = 150  // 定义操作列表宽度
-    let itemData = App.Touches.touchE(e, this.data.itemData, this.data.startX, width)
-    itemData && this.setData({ itemData })
+    let item = App.Touches.touchEnd(e)
+    item && this.setData({ [`itemData[${App.Touches.getItemIndex(e)}]`]: item })
   },
   itemDelete: function(e){  // itemDelete
-    let itemData = App.Touches.deleteItem(e, this.data.itemData)
-    itemData && this.setData({ itemData })
+    this.data.itemData.splice(App.Touches.getItemIndex(e), 1)
+    this.initTouchData()
+    this.setData({ itemData: this.data.itemData })
+  },
+  initTouchData() {
+    App.Touches.initData({
+      datalist: this.data.itemData,
+      operationWrapperWidth: 150
+    })
   },
   onLoad: function (options) {
     // 页面初始化 options为页面跳转所带来的参数
+    this.initTouchData()
   },
   onReady: function () {
     // 页面渲染完成

--- a/utils/Touches.js
+++ b/utils/Touches.js
@@ -1,64 +1,86 @@
 
 class Touches {
-    constructor() {
-
+    dataList = []
+    startClientX = null
+    operationWrapperWidth = null
+  
+    /**
+     * 初始化相关数据
+     * @param {array} dataList 列表数据
+     * @param {number} operationWrapperWidth 左滑出现的操作块宽度
+     */
+    initData({ datalist, operationWrapperWidth }) {
+        this.operationWrapperWidth = operationWrapperWidth
+        this.dataList = datalist instanceof Array
+            ? datalist.concat()
+            : [datalist]
     }
-
-    _getIndex(e) {  // 获取滑动列表的下标值
+  
+    /**
+     * 手指触摸动作开始
+     * 1. 重置数据
+     * 2. 获取触摸起始位置x
+     * @return {array} 被初始化的列表数据
+     */
+    touchStart(e) {
+        this._resetData()
+        this.startClientX = this._getClientX(e)
+        return this.dataList
+    }
+  
+    /**
+     * 手指触摸后移动
+     * @return {object} 当前被操作的item
+     */
+    touchMove(e) {
+        let moveWidth = this._getMoveWidth(e)
+        if (moveWidth > 0) return
+    
+        this.dataList[this.getItemIndex(e)].left = Math.abs(moveWidth) > 150
+            ? -150
+            : moveWidth
+    
+        return this.dataList[this.getItemIndex(e)]
+    }
+  
+    /**
+     * 手指触摸动作结束
+     * @return {object} 当前被操作的item
+     */
+    touchEnd(e) {
+        let moveWidth = this._getMoveWidth(e)
+        let left = 0
+    
+        // 向左滑动 且 滑动的距离已大于操作块宽度的一半
+        if (moveWidth < 0 && Math.abs(moveWidth) > this.operationWrapperWidth / 2) {
+            left = -this.operationWrapperWidth
+        }
+    
+        this.dataList[this.getItemIndex(e)].left = left
+        return this.dataList[this.getItemIndex(e)]
+    }
+  
+    // 获取滑动列表的下标值
+    getItemIndex(e) {
         return e.currentTarget.dataset.index
     }
-
-    _getMoveX(e, startX) {  // 获取滑动过程中滑动的距离
-        return this.getClientX(e) - startX
-    }
-
-    _getEndX(e, startX) {  // 获取滑动结束滑动的距离
+  
+    // 获取当前滑动手势下 距离页面可显示区域的 横坐标
+    _getClientX(e) {
         let touch = e.changedTouches
-        if (touch.length === 1) {
-            return touch[0].clientX - startX
-        }
+        if (touch.length === 1) return touch[0].clientX
     }
-
-    _resetData(dataList) {  // 重置数据， 把所有的列表 left 置为 0
-        for (let i in dataList) {
-            dataList[i].left = 0
-        }
-        return dataList
+  
+    // 获取滑动过程中 滑动的宽度
+    _getMoveWidth(e) {
+        return this._getClientX(e) - this.startClientX
     }
-
-    getClientX(e) {  // 获取滑动的横坐标
-        let touch = e.touches
-        if (touch.length === 1) {
-            return touch[0].clientX
-        }
+  
+    _resetData() {
+        this.startClientX = null
+        this.dataList.forEach(v => { v.left = 0 })
     }
-
-    touchM(e, dataList, startX) {  // touchmove 过程中更新列表数据
-        let list = this._resetData(dataList)
-        list[this._getIndex(e)].left = this._getMoveX(e, startX)
-        return list
-    }
-
-    touchE(e, dataList, startX, width) {  // touchend 更新列表数据
-        let list = this._resetData(dataList)
-        let disX = this._getEndX(e, startX)
-        let left = 0
-
-        if (disX < 0) {  // 判断滑动方向， （向左滑动）
-            // 滑动的距离大于删除宽度的一半就显示操作列表 否则不显示
-            Math.abs(disX) > width / 2 ? left = -width : left = 0
-        } else {  // 向右滑动复位
-            left = 0
-        }
-
-        list[this._getIndex(e)].left = left
-        return list
-    }
-
-    deleteItem(e, dataList) {  // 删除功能
-        dataList.splice(this._getIndex(e), 1)
-        return dataList
-    }
-}
-
-export default Touches
+  }
+  
+  export default Touches
+  

--- a/utils/Touches.js
+++ b/utils/Touches.js
@@ -10,7 +10,7 @@ class Touches {
      * @param {number} operationWrapperWidth 左滑出现的操作块宽度
      */
     initData({ datalist, operationWrapperWidth }) {
-        this.operationWrapperWidth = operationWrapperWidth
+        this.operationWrapperWidth = Math.abs(operationWrapperWidth)
         this.dataList = datalist instanceof Array
             ? datalist.concat()
             : [datalist]
@@ -36,8 +36,8 @@ class Touches {
         let moveWidth = this._getMoveWidth(e)
         if (moveWidth > 0) return
     
-        this.dataList[this.getItemIndex(e)].left = Math.abs(moveWidth) > 150
-            ? -150
+        this.dataList[this.getItemIndex(e)].left = Math.abs(moveWidth) > this.operationWrapperWidth
+            ? -this.operationWrapperWidth
             : moveWidth
     
         return this.dataList[this.getItemIndex(e)]


### PR DESCRIPTION
主要优化点：
- [x] 将列表数据、起始触摸坐标、左滑展示的操作块宽度，放在Touches中管理 避免在再次传入
- [x] touchMove、touchEnd 中进行了dataReset，改为仅在touchStart时进行一次初始化 避免频繁调用
- [x] touchMove、touchEnd 方法 return list 改为 return item。避免直接对列表进行setData，优化性能
- [x] touchMove 中添加对右滑的拦截
- [x] touchMove 修复touch手势不放开，left 远大于操作块宽度的显示 bug
- [x] _getMoveX 和 _getEndX 逻辑一致 合并为 _getMoveWidth
- [x] delete方法移除，操作块中的具体操作逻辑建议放在业务逻辑页面中去完成

@songzeng2016 